### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/galoshes/meta.py
+++ b/galoshes/meta.py
@@ -60,7 +60,7 @@ class AMMetaClass(type):
             warnings.simplefilter('ignore')
             for key in obj.initMap.keys():
                 if (key not in systemConfig) and obj.initMap[key][0]:
-                    raise ValueError('Class %s requires parameter \'%s\''%(cls.__name__, key))
+                    raise ValueError('Class {0!s} requires parameter \'{1!s}\''.format(cls.__name__, key))
                 if key in systemConfig:
                     if obj.initMap[key][2] is None:
                         typer = lambda x: x
@@ -192,7 +192,7 @@ class SCFilter(object):
 
         for key in self.required:
             if key not in systemConfig:
-                raise ValueError('%s requires parameter \'%s\''%(cls.__name__, key))
+                raise ValueError('{0!s} requires parameter \'{1!s}\''.format(cls.__name__, key))
 
         return {key: systemConfig[key] for key in set.union(self.required, self.optional) if key in systemConfig}
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bsmithyman:galoshes?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bsmithyman:galoshes?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
